### PR TITLE
Add method to clear cached data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ settings := YummySettings{
 repo, err := NewRepository(settings)
 
 // To get repomd metadata
-repomd, statusCode, err := r.Repomd()
+repomd, statusCode, err := repo.Repomd()
 
 // To get package metadata
-packages, statusCode, err := r.Packages()
+packages, statusCode, err := repo.Packages()
 
 // To get repository signature
-signature, statusCode, err := r.Signature()
+signature, statusCode, err := repo.Signature()
 ```  
 
 **To parse packages from a yum repository on disk**

--- a/pkg/yum/error.go
+++ b/pkg/yum/error.go
@@ -1,1 +1,0 @@
-package yum

--- a/pkg/yum/repository_test.go
+++ b/pkg/yum/repository_test.go
@@ -47,6 +47,31 @@ func TestConfigure(t *testing.T) {
 	assert.NotEqual(t, firstClient.Timeout, r.settings.Client.Timeout)
 }
 
+func TestClear(t *testing.T) {
+	s := server()
+	defer s.Close()
+
+	c := s.Client()
+	settings := YummySettings{
+		Client: c,
+		URL:    &s.URL,
+	}
+	r, _ := NewRepository(settings)
+
+	_, _, _ = r.Repomd()
+	_, _, _ = r.Packages()
+	_, _, _ = r.Signature()
+	assert.NotNil(t, r.repomd)
+	assert.NotNil(t, r.packages)
+	assert.NotNil(t, r.repomdSignature)
+
+	r.Clear()
+	assert.Nil(t, r.repomd)
+	assert.Nil(t, r.packages)
+	assert.Nil(t, r.repomdSignature)
+
+}
+
 func TestFetchRepomd(t *testing.T) {
 	s := server()
 	defer s.Close()


### PR DESCRIPTION
Adds `repo.Clear()`, which will set `repo.repomd`, `repo.packages`, and `repo.repomdSignature` to `nil`, so that the fetching methods will fetch new data.