### PR TITLE
Fixes 3539: introspection fails if comps file not detected

### DIFF
--- a/pkg/yum/repository.go
+++ b/pkg/yum/repository.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"path/filepath"
 
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/matchers"
@@ -436,17 +435,26 @@ func ParseCompsXML(body io.ReadCloser, url *string) (Comps, error) {
 		return comps, fmt.Errorf("io.reader read failure: %w", err)
 	}
 
-	fileExtension := filepath.Ext(*url)
+	// determine the file type from the header
+	bufferedReader := bufio.NewReader(bytes.NewReader(byteValue))
+	header, err := bufferedReader.Peek(20)
+	if err != nil {
+		return comps, err
+	}
+	fileType, err := filetype.Match(header)
+	if err != nil {
+		return comps, err
+	}
 
-	// handle uncompressed comps
-	if fileExtension == ".xml" || fileExtension == "" {
-		reader = bytes.NewReader(byteValue)
-	} else {
-		// handle compressed comps
+	// handle compressed comps
+	if fileType == matchers.TypeGz || fileType == matchers.TypeZstd || fileType == matchers.TypeXz {
 		reader, err = ParseCompressedData(bytes.NewReader(byteValue))
 		if err != nil {
 			return comps, err
 		}
+		// handle uncompressed comps
+	} else {
+		reader = bytes.NewReader(byteValue)
 	}
 
 	decoder := xml.NewDecoder(reader)

--- a/pkg/yum/repository.go
+++ b/pkg/yum/repository.go
@@ -344,7 +344,9 @@ func (r *Repository) getCompsURL() (*string, error) {
 	var compsLocation string
 
 	for _, data := range r.repomd.Data {
-		if data.Type == "group" {
+		if data.Type == "group_gz" {
+			compsLocation = data.Location.Href
+		} else if data.Type == "group" {
 			compsLocation = data.Location.Href
 		}
 	}
@@ -437,7 +439,7 @@ func ParseCompsXML(body io.ReadCloser, url *string) (Comps, error) {
 	fileExtension := filepath.Ext(*url)
 
 	// handle uncompressed comps
-	if fileExtension == ".xml" {
+	if fileExtension == ".xml" || fileExtension == "" {
 		reader = bytes.NewReader(byteValue)
 	} else {
 		// handle compressed comps


### PR DESCRIPTION
## Summary

Handles case where a repository's comps has no file extension and /or are in either `group_gz` or `group`

## Testing steps

Package groups and environments can be parsed from these repositories: 

http://yum.theforeman.org/pulpcore/3.16/el7/x86_64/ 
http://yum.theforeman.org/pulpcore/3.16/el8/x86_64/

(if there are any other testing steps I can take or repositories to check please let me know) 