### PR TITLE
increases default max xml size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,17 +6,17 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0
 	github.com/h2non/filetype v1.1.3
 	github.com/klauspost/compress v1.17.9
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.9.0
 	github.com/ulikunitz/xz v0.5.12
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/cloudflare/circl v1.3.9 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/yum/repository.go
+++ b/pkg/yum/repository.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Max uncompressed XML file supported
-const DefaultMaxXmlSize = int64(512 * 1024 * 1024) // 512 MB
+const DefaultMaxXmlSize = int64(600 * 1024 * 1024) // 600 MB
 
 // Package metadata of a given package
 type Package struct {

--- a/pkg/yum/repository.go
+++ b/pkg/yum/repository.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Max uncompressed XML file supported
-const DefaultMaxXmlSize = int64(600 * 1024 * 1024) // 600 MB
+const DefaultMaxXmlSize = int64(1024 * 1024 * 1024) // 1 GB
 
 // Package metadata of a given package
 type Package struct {


### PR DESCRIPTION
Introspection of the RHEL9 arm baseos repo is failing with this error (`error introspecting https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/: XML syntax error on line 6371618: unexpected EOF`) because the uncompressed file is larger than the default we have set (about 3MB larger). This changes the default max xml size to be 1GB.

To test:

1. Replace yummy in the backend's go.mod with this PR (`replace github.com/content-services/yummy => /path/to/repo`)
2. Introspect the RHEL9 arm baseos repo: `./release/external-repos introspect --url https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/`. It should introspect successfully.   