### PR TITLE
fix: increase max XML size to 1.5GB

### DIFF
--- a/pkg/yum/repository.go
+++ b/pkg/yum/repository.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Max uncompressed XML file supported
-const DefaultMaxXmlSize = int64(1024 * 1024 * 1024) // 1 GB
+const DefaultMaxXmlSize = int64(1024 * 1024 * 1024 * 3 / 2) // 1.5 GB
 
 // Package metadata of a given package
 type Package struct {


### PR DESCRIPTION
Some repos (RHEL 9.8 EUS/E4S aarch64 baseos) exceed 1GB. This increases the max XML size yummy can parse.

Testing steps:

1. Use your local yummy directory as the backend yummy package in content-sources-backend/go.mod and run `go mod tidy`:

`replace [github.com/content-services/yummy](http://github.com/content-services/yummy) => /path/to/yummy`

2. Try to introspect a large repo (https://cdn.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/ or https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/). It shouldn't fail. 

3. Without this PR, you'll see an error like this: 

```
An introspection error occurred: XML syntax error on line 12654284: unexpected EOF
```